### PR TITLE
Fix font style return

### DIFF
--- a/createDefinitions.js
+++ b/createDefinitions.js
@@ -66,7 +66,7 @@ function parseIconsFile(obj) {
             var symbol = '\\symbol{"' + obj[i].unicode.toUpperCase() + '}'
             
             //Concatenate the string
-            var str = start + name + suffix + '{' + prefix + symbol + '}'
+            var str = start + name + suffix + '{' + '{' + prefix + symbol + '}' + '}'
             
             //add to results
             results.push(str);


### PR DESCRIPTION
When using a FontAwesome symbol, any text after the icon is not returned to its original state. We enclose the command with another set of {} limiting \newfontfamily to the command only.